### PR TITLE
lmsdisasm: allow disassembly of "block"s with non-zero local_bytes

### DIFF
--- a/EV3/lms2012.py
+++ b/EV3/lms2012.py
@@ -1692,7 +1692,7 @@ class ObjectHeader(LittleEndianStructure):
 
     @property
     def is_block(self):
-        return self.owner != 0 and self.local_bytes == 0
+        return self.owner != 0
 
 LC0_MIN = -31
 LC0_MAX = 31


### PR DESCRIPTION
I do not know whether the test for self.local_bytes in is_block() should be changed to != 0 instead of == 0 rather than simply removing the test as I have in this commit.

The [ColorSensorRGB](http://mindcuber.com/mindcub3r/mindcub3r.html#ColorSensorRGBBlock) block present in the MindCub3r project has a non-zero value for local_bytes so I have proposed removing the test on the assumption that the == 0 case was tested and therefore may occur too.
